### PR TITLE
Copy editing slides

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -1051,7 +1051,7 @@
         
         ```
         function greeting($name) {
-          echo "Hello $name!"; // code to be executed
+          echo "Hello ", $name, "!"; // code to be executed
         }
         ```
         Now *call* the function with an argument.
@@ -1215,8 +1215,6 @@
           function theme_enqueue_styles() {
               wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
           }
-          
-          ?>
           ```
           
           And that's it!

--- a/slides.html
+++ b/slides.html
@@ -147,9 +147,9 @@
         
         This depends on the level of customization required. 
         
-        However, much of the customizations can be achieved using WordPress [template tags](http://codex.wordpress.org/Template_Tags) and are all documented in the Codex.
+        However, much of the customization can be achieved using WordPress [template tags](http://codex.wordpress.org/Template_Tags), which are all documented in the Codex.
         
-        We'll also discuss the different levels of customizations.
+        We'll also discuss the different levels of customization.
       </script>
     </section>
     
@@ -178,7 +178,7 @@
         Today we'll be using the [DesktopServer](https://serverpress.com) from ServerPress.  
         
         ---
-        <!-- .element: class="note" -->[Mamp](https://www.mamp.info/en/) is a very popular & common option for local servers and has more features than the free version of DesktopServer but this app streamlines the WordPress installation process. The extra features contained in Mamp are not needed for today.
+        <!-- .element: class="note" -->[Mamp](https://www.mamp.info/en/) is a very popular &amp; common option for local servers and has more features than the free version of DesktopServer, but DesktopServer streamlines the WordPress installation process. The extra features contained in Mamp are not needed for today.
       </script>
     </section>
     
@@ -233,7 +233,7 @@
         ![](framework/img/workshop/admin-login-tabs.gif)
         
         ---
-        ###Resources
+        ###Resource
         
         * http://www.wpbeginner.com/glossary/admin-area/
       </script>
@@ -253,7 +253,7 @@
         * uploading media (**Media**)
         * other general site settings
         
-        <!-- .element: class="note" -->**Note**: that the content or settings updates added in any of the Admin area options are stored in your database.  That's how the CMS retains the content, even when you change the theme.
+        <!-- .element: class="note" -->**Note**: The content or settings updates added in any of the Admin area options are stored in your database.  That's how the CMS retains the content, even when you change the theme.
       </script>
     </section>
     
@@ -292,7 +292,7 @@
       <script type="text/template">
         # Post Type: Pages
         
-        ![](framework/img/workshop/admin-posts.png)  
+        ![](framework/img/workshop/admin-pages.png)  
 
         * used for static content (e.g. About)
         * cannot have taxonomies
@@ -389,7 +389,7 @@
 
         **Menus** are used to create the site navigation (links to pages, categories, tags, etc).
         
-        The **Header** & **Background** menu allows you to manage images/colors displayed in the header and background of the theme.  
+        The **Header** &amp; **Background** menus allow you to manage images/colours displayed in the header and background of the theme.  
         
         This option will only be present if the theme author has configured these options to allow for this capability.
         
@@ -408,8 +408,8 @@
       <script type="text/template">
         #Theme Options
         
-        ##Option 1: Free & Premium Themes
-        * pay for domain, hosting & cost of theme (from free to a few hundred)
+        ##Option 1: Free &amp; Premium Themes
+        * pay for domain, hosting &amp; cost of theme (from free to a few hundred dollars)
         * does not require coding (though you have access to the codebase)
         * includes some customization options that can be updated in the **Customize** menu
         
@@ -451,7 +451,7 @@
         
         * Go to **Appearance > Themes**, select **Add New**.  
         * Search for the "Sydney" theme.  
-        * Select **Install** and **activate** when the installation is complete.
+        * Select **Install** and **Activate** when the installation is complete.
         
         ![](framework/img/workshop/admin-themes-add.gif)<!-- .element: width="80%" -->
       </script>
@@ -490,7 +490,7 @@
       <script type="text/template">
         # Appearance > Customize
       
-        These options listed here will be specific to the active theme and will vary based on what features were made available by the theme author. 
+        The options listed here will be specific to the active theme and will vary based on what features were made available by the theme author. 
         
         Navigate to the **Customize** menu to view the options for this theme.
         
@@ -502,7 +502,7 @@
       <script type="text/template">
         #Customize: Site title / tagline / logo
         
-        This setting shows options for displaying text or a logo in the header. Reminder, the **Customize** menu shows options specific to the theme.
+        This setting shows options for displaying text or a logo in the header. Remember, the **Customize** menu shows options specific to the theme.
         
         ![](framework/img/workshop/admin-customize-title.gif)<!-- .element: width="80%" -->
       </script>
@@ -528,7 +528,7 @@
         
         ![](framework/img/workshop/appearance-admin.png)<!-- .element: width="350px" -->
         
-        The Customize options are specific to the theme and will vary but the options under Appearance are available for any theme.
+        The Customize options are specific to the theme and will vary, but the options under Appearance are available for any theme.
       </script>
     </section>
     
@@ -552,7 +552,7 @@
         
         ![](framework/img/workshop/menu-default.png)<!-- .element: class="left" height="600" -->
         
-        Since WordPress starting as a blogging platform, the default homepage for all WordPress sites is a listing of your blog posts.
+        Since WordPress started as a blogging platform, the default homepage for all WordPress sites is a listing of your blog posts.
         
         Blog page *templates* also generally default to include a sidebar with widgets (Recent Posts, Recent Comments, etc).
         
@@ -564,7 +564,7 @@
       <script type="text/template">
         # Custom Menu
         
-        If the default homepage is a listing of latest blog posts, how do create and navigate to a homepage? What if you wanted a navigation that looked like this:
+        If the default homepage is a listing of latest blog posts, how do you create and navigate to a homepage? What if you wanted a navigation that looked like this:
         
         ![](framework/img/workshop/custom-menu.png)
         
@@ -685,7 +685,7 @@
         
         ![](framework/img/workshop/theme-template.png)<!-- .element: class="left" -->
         
-        WordPress is based on PHP so the files must use a `.php` extension.
+        WordPress is based on PHP, so the files must use a `.php` extension.
         
         WordPress also has specific naming conventions for template files. (e.g. header.php is for header content)
         
@@ -784,7 +784,7 @@
                 
         **How much PHP do you need to know?**
         
-        Though WordPress is written in PHP, much of your customizations can be accomplished by using WordPress specific PHP, *template tags*.  
+        Though WordPress is written in PHP, much of your customizations can be accomplished by using WordPress-specific PHP, *template tags*.  
         
         However, being able to recognize PHP tags and having a general grasp of the PHP syntax will help a lot. 
         
@@ -837,7 +837,7 @@
         <p>More HTML. Dynamic code here: <?php PHP code ?></p>
         ```
         
-        These technique are used quite often in WordPress.
+        These techniques are used quite often in WordPress.
       </script>
     </section>
     
@@ -1068,16 +1068,16 @@
         
         In WordPress, many of the complexities required for displaying content have already been created as **template tags**. Some common template tags are:
         
-        * `get_header()` gets the header.php template file and includes it (and it's content) in the current file. 
+        * `get_header()` - gets the header.php template file and includes it (and its content) in the current file. 
         * `the_title()` – tells WordPress to get the title of the page or post from the database
         * `bloginfo('name')` – tells WordPress to get the blog/website title from the database
         
         Notice that the syntax is just like the previous examples for calling a function? That's because they are functions! 
         
         ---
-        ###Resources
+        ###Resource
         
-        * Complete listing & documentation of [WordPress template tags](https://codex.wordpress.org/Template_Tags)
+        * Complete listing &amp; documentation of [WordPress template tags](https://codex.wordpress.org/Template_Tags)
       </script>
     </section>
     
@@ -1139,7 +1139,7 @@
         If you modify a theme's files directly and it is updated, your modifications may be lost. By using a child theme your modifications will be preserved.
         
         ---
-        ###Resource 
+        ###Resource
         * https://codex.wordpress.org/Child_Themes
       </script>
     </section>
@@ -1475,7 +1475,7 @@
         * the `have_posts()` function checks if there are any posts (true/false)
         * the `if` condition is true as long as there are posts
         * a `while` loop continues to execute as long as the condition in true
-        * the while loops contains instructions for what content to display, from the posts
+        * the while loop contains instructions for what content to display, from the posts
         
         ```php
         <?php if ( have_posts() ) : ?> // if we have posts
@@ -1528,7 +1528,7 @@
       <script type="text/template">
         #Class Exercise: Editing Templates
         
-        Copy `content-page.php` from the parent them folder to the child theme folder to make edits.
+        Copy `content-page.php` from the parent theme folder to the child theme folder to make edits.
         
         Compare the code to the snippet we found when inspecting the page.
         
@@ -1555,7 +1555,7 @@
       <script type="text/template">
         #Class Exercise: Remove the Sidebar
         
-        Back in `page.php`, let's make anoter edit.  There's no need to show archives & recent blog posts on a static page. 
+        Back in `page.php`, let's make another edit.  There's no need to show archives &amp; recent blog posts on a static page. 
         
         Find the snippet and delete it! Look for this template tag:
         
@@ -1565,7 +1565,7 @@
         
         This [template tag](https://codex.wordpress.org/Function_Reference/get_sidebar) is used to include the `sidebar.php` file. Delete it and the sidebar content will no longer be pulled into this page but is still available for use on the blog page (or any other template).
         
-        You can also delete the whole `comments_template();` block if you don't want to include comments on your page template as well.
+        You can also delete the whole `comments_template();` block if you don't want to include comments on your page template.
       </script>
     </section>
     
@@ -1611,7 +1611,7 @@
         
         **Selectors** are used to determine which HTML element(s) to apply the styles to.
         
-        **Properties** determine the type of style to be applied to the element (e.g. color). Values are specific to the property (e.g. red). 
+        **Properties** determine the type of style to be applied to the element (e.g. colour). Values are specific to the property (e.g. red). 
         
         **Declarations** are style rules, written using `property:value` pairs, are wrapped by curly brackets `{}` and each must end with a semi-colon `;` to indicate that the instruction is complete.
         
@@ -1648,7 +1648,7 @@
         ```
         ```css
         #page {
-            color: #444; /* selects all matching HTML elements with this id */
+            color: #444; /* selects the HTML element with this id (there should be only one) */
         }
         ```
       </script>
@@ -1694,7 +1694,7 @@
           color: black;
         }
         ```
-        In the above example, the CSS properties in the body selector is inherited by the descendants elements (all nested elements). 
+        In the above example, the CSS properties in the body selector is inherited by the descendant elements (all nested elements). 
         
         However, when a more *specific* selector is used (e.g. h1), it will override the inherited values.
       </script>
@@ -1752,7 +1752,7 @@
       <script type="text/template">
         #Update style.css
         
-        Uh oh. Only the `font-size` changed but not the color? Inspecting the element shows that (1) the new css *is* loaded and (2) the `font-size` *is* overriding the previous styles. But still no color change.
+        Uh oh. Only the `font-size` changed but not the `color`? Inspecting the element shows that (1) the new css *is* loaded and (2) the `font-size` *is* overriding the previous styles. But still no colour change.
         
         **Hint**: See the arrow beside the `<h2>`? Click to open.
         
@@ -1764,7 +1764,7 @@
       <script type="text/template">
         #Update style.css 
         
-        The color of this heading uses a *different* selector, one that targets the link *inside* of the `<h1>` tag. That's why the CSS wasn't working.
+        The colour of this heading uses a *different* selector, one that targets the link *inside* of the `<h1>` tag. That's why the CSS wasn't working.
         
         ![](framework/img/workshop/inspect-element-css-2.gif)
       </script>
@@ -1776,7 +1776,7 @@
         
         There are two selectors used to set the colour. How do you know which one to use?
         
-        When inspecting the element, #1 in example shows as crossed out. That means a more specific selector (the one not crossed out) is overriding it. So, the #2 selector should be used.  
+        When inspecting the element, #1 in the example is crossed out. That means a more specific selector (the one not crossed out) is overriding it. So, the #2 selector should be used.  
         
         ![](framework/img/workshop/css-change-2.png)
       </script>
@@ -1794,7 +1794,7 @@
         
         This snippet shows that all links (`a`) contained within all of the headings (`h1, h2, etc`) show the same colour.
         
-        If you only want to change the color for *this* specific heading, use just `h2 a` as your selector. When multiple selectors are combined, the specific element being inspected will be highlighted.
+        If you only want to change the colour for *this* specific heading, use just `h2 a` as your selector. When multiple selectors are combined, the specific element being inspected will be highlighted.
         
         ![](framework/img/workshop/inspect-css-selectors.png)<!-- .element: width="50%" -->
       </script>


### PR DESCRIPTION
- Clarified that HTML ids should be unique on a page
- Standardized spelling of "colour" except when referring to CSS property `color` -- was using a mix of the two
- Standardized heading "Resource" with only one bullet -- previously "Resources" was sometimes used in this case
- Typo, spelling, and grammar corrections
- `&` => `&amp;`
- Fixed wrong image on slide (`admin-posts.png` displayed twice)
