### PR TITLE
Make the HTML and CSS match for the id portion of slide 96

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -1642,10 +1642,10 @@
         }
         ```
         ```xml
-        <h1 id="site-title">Heading</h1>
+        <h1 id="page-title">Heading</h1>
         ```
         ```css
-        #page {
+        #page-title {
             color: #444; /* selects the HTML element with this id (there should be only one) */
         }
         ```


### PR DESCRIPTION
Tiny change I think would help clarify the use of id selectors.
![](https://media0.giphy.com/media/13XW2MJE0XCoM0/200w.gif)