### PR TITLE
Update slide 6 to reference new wordpress.com plugin capability

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -112,12 +112,12 @@
           * has fewer options for customizing
           * do not need to edit the code
           * some paid upgrades available for some customization
-          * no plugins :(
+          * plugins available with paid Business Plan
         * WordPress**.org**
           * provides the codebase for free to download & edit
           * must purchase your own domain and hosting 
           * you have full control over theme files & code
-          * plugins :)
+          * plugins always available :)
         
         Today we'll be exploring the **.org** version.
 


### PR DESCRIPTION
WordPress.com now offers plugins as part of the paid Business Plan:
https://en.support.wordpress.com/com-vs-org/